### PR TITLE
Handle UTF-8 BOM in labels file

### DIFF
--- a/python/runner/wai_runner.py
+++ b/python/runner/wai_runner.py
@@ -33,7 +33,7 @@ def load_models():
     labels = []
 
     if (MODEL_DIR / "labels.txt").exists():
-        with open(MODEL_DIR / "labels.txt") as f:
+        with open(MODEL_DIR / "labels.txt", encoding="utf-8-sig") as f:
             labels = [l.strip() for l in f if l.strip()]
 
     if ort and (MODEL_DIR / "model.onnx").exists():

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,19 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+# Provide stub for cv2 to avoid system dependency issues during import
+sys.modules['cv2'] = types.ModuleType('cv2')
+
+spec = importlib.util.spec_from_file_location(
+    'wai_runner',
+    Path(__file__).resolve().parents[1] / 'python' / 'runner' / 'wai_runner.py'
+)
+wai_runner = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(wai_runner)
+
+
+def test_first_label_utf8_sig():
+    _, _, labels = wai_runner.load_models()
+    assert labels and labels[0] == "Abert's Towhee"


### PR DESCRIPTION
## Summary
- fix `load_models` to read `labels.txt` with `utf-8-sig` encoding
- add test ensuring first label is parsed correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68817cde589883228292bab269dd08ea