### PR TITLE
Add keyword helper without write lock

### DIFF
--- a/plugin/WildlifeAI.lrplugin/KeywordHelper.lua
+++ b/plugin/WildlifeAI.lrplugin/KeywordHelper.lua
@@ -15,6 +15,22 @@ local function bucket(v)
   local start = math.floor(n/10)*10
   return start .. '-' .. (start + 9)
 end
+
+function M.applyKeywords_noWrite(photo, root, data)
+  Log.enter('KeywordHelper.applyKeywords_noWrite')
+  local catalog = LrApplication.activeCatalog()
+  local spec = (data.detected_species and data.detected_species ~= '' and data.detected_species) or 'Unknown'
+  local kws = {
+    {root, 'Species', spec},
+    {root, 'Quality', bucket(data.quality)},
+    {root, 'Confidence', bucket(data.species_confidence)},
+  }
+  for _,parts in ipairs(kws) do
+    local kw = getOrCreateKeyword(catalog, parts)
+    if kw then photo:addKeyword(kw) end
+  end
+  Log.leave('KeywordHelper.applyKeywords_noWrite')
+end
 function M.apply(photo, root, data)
   Log.enter('KeywordHelper.apply')
   local catalog = LrApplication.activeCatalog()


### PR DESCRIPTION
## Summary
- add `applyKeywords_noWrite` helper to insert keywords without starting its own write transaction

## Testing
- `luac -p plugin/WildlifeAI.lrplugin/KeywordHelper.lua`
- `git ls-files '*.lua' | xargs -I{} luac -p {}`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68817cdf15208322875a0185c3cb3503