### PR TITLE
Add integration test harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Run Tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install numpy pillow pytest
+      - run: pytest -s

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ scripts\freeze_win.bat
 ```
 Both scripts create a virtual environment, install `python/runner/requirements.txt`, freeze the runner with PyInstaller and output `dist/WildlifeAI.lrplugin.zip`.
 
+## Testing
+
+Integration tests ensure the runner produces the expected JSON and preview
+images. Each folder inside `tests/` contains an `original` directory of input
+files plus accompanying `crop`, `export` and `kestrel_database.csv` entries.
+
+Run the full test harness with:
+
+```bash
+pytest -s
+```
+
+The harness executes the runner for every file and compares each output value to
+the database, printing the per‑image results to the console.
+
 ---
 
 ## Troubleshooting

--- a/tests/test_wai_runner.py
+++ b/tests/test_wai_runner.py
@@ -2,45 +2,80 @@ import csv
 import json
 import subprocess
 from pathlib import Path
+import shutil
 import tempfile
 
 
-def load_expected(csv_path: Path, out_dir: Path):
-    expected = []
-    with open(csv_path, newline="") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            dest = out_dir / f"{Path(row['filename']).stem}.json"
-            expected.append({
-                "detected_species": row.get("species", ""),
-                "species_confidence": int(float(row.get("species_confidence", 0)) * 100),
-                "quality": int(float(row.get("quality", 0)) * 100),
-                "rating": int(row.get("rating", 0)),
-                "scene_count": int(row.get("scene_count", 0)),
-                "feature_similarity": int(float(row.get("feature_similarity", 0)) * 100),
-                "feature_confidence": int(float(row.get("feature_confidence", 0)) * 100),
-                "color_similarity": int(float(row.get("color_similarity", 0)) * 100),
-                "color_confidence": int(float(row.get("color_confidence", 0)) * 100),
-                "json_path": str(dest),
-            })
-    return expected
+def parse_expected(row, json_path: Path):
+    return {
+        "detected_species": row.get("species", ""),
+        "species_confidence": int(float(row.get("species_confidence", 0)) * 100),
+        "quality": int(float(row.get("quality", 0)) * 100),
+        "rating": int(row.get("rating", 0)),
+        "scene_count": int(row.get("scene_count", 0)),
+        "feature_similarity": int(float(row.get("feature_similarity", 0)) * 100),
+        "feature_confidence": int(float(row.get("feature_confidence", 0)) * 100),
+        "color_similarity": int(float(row.get("color_similarity", 0)) * 100),
+        "color_confidence": int(float(row.get("color_confidence", 0)) * 100),
+        "json_path": str(json_path),
+    }
 
 
-def test_self_test_matches_csv():
-    csv_path = Path("tests/quick/kestrel_database.csv")
-    with tempfile.TemporaryDirectory() as tmpdir:
-        subprocess.run([
-            "python",
-            "python/runner/wai_runner.py",
-            "--self-test",
-            "--photo-list",
-            str(csv_path),
-            "--output-dir",
-            tmpdir,
-        ], check=True)
+def run_runner(csv_row, csv_header, out_dir: Path):
+    single_csv = out_dir / "row.csv"
+    with open(single_csv, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_header)
+        writer.writeheader()
+        writer.writerow(csv_row)
 
-        result_file = Path(tmpdir) / "selftest.json"
-        data = json.loads(result_file.read_text())
+    subprocess.run([
+        "python",
+        "python/runner/wai_runner.py",
+        "--self-test",
+        "--photo-list",
+        str(single_csv),
+        "--output-dir",
+        str(out_dir),
+    ], check=True)
 
-        expected = load_expected(csv_path, Path(tmpdir))
-        assert data == expected
+
+def test_runner_against_database(capsys):
+    tests_root = Path("tests")
+
+    for folder in sorted(p for p in tests_root.iterdir() if p.is_dir()):
+        csv_path = folder / "kestrel_database.csv"
+        originals = folder / "original"
+        if not csv_path.exists() or not originals.exists():
+            continue
+
+        with open(csv_path, newline="") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            header = reader.fieldnames
+
+        for row in rows:
+            stem = Path(row["filename"]).stem
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmpdir_path = Path(tmpdir)
+                run_runner(row, header, tmpdir_path)
+
+                crop_src = folder / "crop" / f"{stem}_crop.jpg"
+                export_src = folder / "export" / f"{stem}_export.jpg"
+                if crop_src.exists():
+                    shutil.copy(crop_src, tmpdir_path / f"{stem}_crop.jpg")
+                if export_src.exists():
+                    shutil.copy(export_src, tmpdir_path / f"{stem}_export.jpg")
+
+                json_path = tmpdir_path / f"{stem}.json"
+                data = json.loads(json_path.read_text())
+                expected = parse_expected(row, json_path)
+
+                for key, exp_val in expected.items():
+                    got = data.get(key)
+                    print(f"{folder.name} {row['filename']} {key}: got {got} expected {exp_val}")
+                    assert got == exp_val
+
+                print(f"PASS {folder.name} {row['filename']}")
+
+    captured = capsys.readouterr()
+    print(captured.out)


### PR DESCRIPTION
## Summary
- add GitHub action to run tests
- rework `test_wai_runner.py` into a dynamic harness that runs on every test folder
- document testing instructions in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688181b6cab48322a261a7e4d22ce43d