### PR TITLE
Add instructions for automatic plugin builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 ## Building From Source
 
 Prebuilt plug‑ins are produced by the GitHub workflow, but you can build locally with Python 3.11.
+Each push to the `main` branch triggers the workflow and uploads `WildlifeAI.lrplugin.zip` as an artifact—see `docs/BUILDING.md` for download steps.
 
 ### Windows
 ```cmd

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -30,6 +30,20 @@ is zipped to `dist\WildlifeAI.lrplugin.zip`.
 The steps mirror the Windows script and produce
 `dist/WildlifeAI.lrplugin.zip` containing the macOS binary.
 
+## Automatic Builds with GitHub Actions
+
+If your repository is hosted on GitHub you can enable continuous builds using
+the provided workflow in `.github/workflows/build.yml`. It runs on every push to
+the `main` branch and packages the plug‑in automatically.
+
+1. Push your changes to GitHub.
+2. Open the repository's **Actions** tab and select the latest **Build Lightroom
+   Plugin** run.
+3. Download `WildlifeAI.lrplugin.zip` from the **Artifacts** section.
+
+Each run will produce a fresh archive in `dist/` that can be installed in
+Lightroom.
+
 ## Manual Packaging
 
 To rebuild the archive after making manual changes to the plug-in files run:


### PR DESCRIPTION
## Summary
- document GitHub Actions workflow for automatic builds
- note automatic artifact uploads in README

## Testing
- `pip install numpy pillow pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688188edc5ec832290bf3a6a3bce1bfa