### PR TITLE
Fix test failures after build

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Run the full test harness with:
 ```bash
 pytest -s
 ```
+Ensure all Python dependencies are installed before running the tests. The build
+scripts create a `venv` directory containing these requirements—activate it
+using `venv\Scripts\activate` on Windows or `source venv/bin/activate` on
+macOS/Linux, then run `pytest`.
 
 The harness executes the runner for every file and compares each output value to
 the database, printing the per‑image results to the console.


### PR DESCRIPTION
## Summary
- clarify that tests should run inside the virtual environment created by the build scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818a55c0c08322829babd0dc5d9b83