### PR TITLE
Include runtime DLLs in PyInstaller spec

### DIFF
--- a/wildlifeai_runner_cpu.spec
+++ b/wildlifeai_runner_cpu.spec
@@ -7,6 +7,13 @@ from PyInstaller.utils.hooks import collect_all, collect_dynamic_libs
 tf_datas, tf_bins, tf_hidden = collect_all("tensorflow")
 ort_datas, ort_bins, ort_hidden = collect_all("onnxruntime")
 torch_bins = collect_dynamic_libs("torch")
+# Collect Microsoft runtime and OpenMP libraries if present
+runtime_bins = []
+for lib in ["msvcp140", "vcruntime140", "libiomp5md"]:
+    try:
+        runtime_bins += collect_dynamic_libs(lib)
+    except Exception:
+        pass
 
 # Get the current directory and set up paths
 current_dir = Path.cwd()
@@ -79,7 +86,7 @@ hiddenimports = [
 
 # Append collected items
 datas += tf_datas + ort_datas
-binaries += tf_bins + ort_bins + torch_bins
+binaries += tf_bins + ort_bins + torch_bins + runtime_bins
 hiddenimports += tf_hidden + ort_hidden
 
 a = Analysis(


### PR DESCRIPTION
## Summary
- Include Microsoft runtime and OpenMP DLLs when building the CPU runner
- Reference collected runtime DLLs in PyInstaller binaries list

## Testing
- `pyinstaller --clean wildlifeai_runner_cpu.spec`
- `pytest` *(fails: fixture 'test_images' not found; model loading assertions, missing fields, KeyError 'detected_species', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68912fd7e7cc83228d3be6f405a2e27d