### PR TITLE
Pin TensorFlow 2.18 and update build scripts

### DIFF
--- a/python/runner/requirements.txt
+++ b/python/runner/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2.4.1
 torchvision>=0.19.1
-tensorflow>=2.19.0
+tensorflow>=2.18,<2.19
 onnxruntime-directml>=1.22.0   # use onnxruntime on macOS
 numpy>=2.1.3
 opencv-python>=4.11.0

--- a/scripts/build_and_test.bat
+++ b/scripts/build_and_test.bat
@@ -4,6 +4,9 @@ setlocal enabledelayedexpansion
 REM Build the runner and package the plugin
 call "%~dp0freeze_wildlifeai_win.bat" || exit /b 1
 
+REM Ensure Python dependencies are up to date
+python -m pip install --upgrade -r python\runner\requirements.txt || exit /b 1
+
 REM Prepare photo list from test images
 set "PHOTO_LIST=%TEMP%\wai_photos.txt"
 (for %%F in ("%~dp0..\tests\quick\original\*.ARW") do @echo %%~fF) > "%PHOTO_LIST%"

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -17,7 +17,7 @@ source venv/bin/activate
 pip install --upgrade pip >/dev/null
 # onnxruntime-directml is Windows-specific; skip if unavailable
 grep -v onnxruntime-directml python/runner/requirements.txt > "$ROOT_DIR/requirements.tmp"
-pip install -r "$ROOT_DIR/requirements.tmp" pyinstaller >/dev/null
+pip install --upgrade -r "$ROOT_DIR/requirements.tmp" pyinstaller >/dev/null
 pyinstaller python/runner/wai_runner.py --onefile --name kestrel_runner >/dev/null
 
 # Package plugin with built runner


### PR DESCRIPTION
## Summary
- Require TensorFlow 2.18 in runner requirements
- Ensure build scripts reinstall dependencies so new TensorFlow version is picked up

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68965be4c8b48322b8b9074a57a6a483