### PR TITLE
Add bracket stacking settings tab

### DIFF
--- a/plugin/WildlifeAI.lrplugin/UI/ConfigDialog.lua
+++ b/plugin/WildlifeAI.lrplugin/UI/ConfigDialog.lua
@@ -166,7 +166,23 @@ return function(context)
   if prefs.keywordSceneCount == nil then prefs.keywordSceneCount = true end
   if prefs.keywordDetectedSpecies == nil then prefs.keywordDetectedSpecies = true end
   if prefs.keywordSpeciesUnderSpeciesRoot == nil then prefs.keywordSpeciesUnderSpeciesRoot = false end
-  
+
+  -- Bracket stacking defaults
+  if prefs.enableBracketStacking == nil then prefs.enableBracketStacking = false end
+  prefs.defaultBracketSize = prefs.defaultBracketSize or 3
+  prefs.customBracketSize = prefs.customBracketSize or 3
+  prefs.withinBracketInterval = prefs.withinBracketInterval or 2
+  prefs.betweenBracketInterval = prefs.betweenBracketInterval or 10
+  if prefs.matchExposureSettings == nil then prefs.matchExposureSettings = true end
+  prefs.exposureEvTolerance = prefs.exposureEvTolerance or 1.0
+  if prefs.enablePanoramaDetection == nil then prefs.enablePanoramaDetection = false end
+  prefs.panoramaMinFrames = prefs.panoramaMinFrames or 3
+  prefs.panoramaInterval = prefs.panoramaInterval or 5
+  if prefs.collapseBracketStacks == nil then prefs.collapseBracketStacks = true end
+  if prefs.middleExposureOnTop == nil then prefs.middleExposureOnTop = true end
+  if prefs.showBracketPreview == nil then prefs.showBracketPreview = false end
+  prefs.previewDelay = prefs.previewDelay or 0
+
   -- Create validation properties with proper function context
   local props = LrBinding.makePropertyTable(context)
   props.validationError = ''
@@ -1060,26 +1076,229 @@ return function(context)
       }
     }
   }
-  
-  -- Main dialog content with two-column layout
+  -- General settings tab (existing content)
+  local generalTab = f:row {
+    spacing = 15,
+    leftColumn,
+    rightColumn
+  }
+
+  -- Bracket stacking tab
+  local bracketTab = f:column {
+    spacing = f:control_spacing(),
+
+    f:group_box {
+      title = 'Basic Settings',
+      fill_horizontal = 1,
+      spacing = f:control_spacing(),
+
+      f:checkbox {
+        title = 'Enable automatic bracket stacking',
+        value = bind('enableBracketStacking')
+      },
+
+      f:spacer { height = 5 },
+
+      f:row {
+        f:static_text {
+          title = 'Default bracket size:',
+          width = 150,
+          alignment = 'right'
+        },
+        f:popup_menu {
+          value = bind('defaultBracketSize'),
+          items = {
+            { title = '3', value = 3 },
+            { title = '5', value = 5 },
+            { title = '7', value = 7 },
+            { title = 'Custom', value = 'custom' }
+          },
+          immediate = true,
+          width = 80
+        },
+        f:edit_field {
+          value = bind('customBracketSize'),
+          width_in_chars = 6,
+          enabled = bind {
+            key = 'defaultBracketSize',
+            transform = function(value) return value == 'custom' end
+          }
+        }
+      }
+    },
+
+    f:spacer { height = 10 },
+
+    f:group_box {
+      title = 'Time Thresholds',
+      fill_horizontal = 1,
+      spacing = f:control_spacing(),
+
+      f:row {
+        f:static_text {
+          title = 'Within bracket (sec):',
+          width = 150,
+          alignment = 'right'
+        },
+        f:edit_field {
+          value = bind('withinBracketInterval'),
+          width_in_chars = 8,
+          immediate = true
+        }
+      },
+
+      f:row {
+        f:static_text {
+          title = 'Between brackets (sec):',
+          width = 150,
+          alignment = 'right'
+        },
+        f:edit_field {
+          value = bind('betweenBracketInterval'),
+          width_in_chars = 8,
+          immediate = true
+        }
+      }
+    },
+
+    f:spacer { height = 10 },
+
+    f:group_box {
+      title = 'Exposure Analysis',
+      fill_horizontal = 1,
+      spacing = f:control_spacing(),
+
+      f:checkbox {
+        title = 'Match exposure settings',
+        value = bind('matchExposureSettings')
+      },
+
+      f:row {
+        f:static_text {
+          title = 'EV tolerance:',
+          width = 150,
+          alignment = 'right'
+        },
+        f:edit_field {
+          value = bind('exposureEvTolerance'),
+          width_in_chars = 8,
+          immediate = true
+        }
+      }
+    },
+
+    f:spacer { height = 10 },
+
+    f:group_box {
+      title = 'Panorama Detection',
+      fill_horizontal = 1,
+      spacing = f:control_spacing(),
+
+      f:checkbox {
+        title = 'Detect panoramas',
+        value = bind('enablePanoramaDetection')
+      },
+
+      f:row {
+        enabled = bind('enablePanoramaDetection'),
+        f:static_text {
+          title = 'Minimum frames:',
+          width = 150,
+          alignment = 'right'
+        },
+        f:edit_field {
+          value = bind('panoramaMinFrames'),
+          width_in_chars = 8,
+          immediate = true
+        }
+      },
+
+      f:row {
+        enabled = bind('enablePanoramaDetection'),
+        f:static_text {
+          title = 'Max gap (sec):',
+          width = 150,
+          alignment = 'right'
+        },
+        f:edit_field {
+          value = bind('panoramaInterval'),
+          width_in_chars = 8,
+          immediate = true
+        }
+      }
+    },
+
+    f:spacer { height = 10 },
+
+    f:group_box {
+      title = 'Stack Behavior',
+      fill_horizontal = 1,
+      spacing = f:control_spacing(),
+
+      f:checkbox {
+        title = 'Collapse stacks after creation',
+        value = bind('collapseBracketStacks')
+      },
+
+      f:checkbox {
+        title = 'Put middle exposure on top',
+        value = bind('middleExposureOnTop')
+      }
+    },
+
+    f:spacer { height = 10 },
+
+    f:group_box {
+      title = 'Preview',
+      fill_horizontal = 1,
+      spacing = f:control_spacing(),
+
+      f:checkbox {
+        title = 'Show preview before stacking',
+        value = bind('showBracketPreview')
+      },
+
+      f:row {
+        enabled = bind('showBracketPreview'),
+        f:static_text {
+          title = 'Preview delay (sec):',
+          width = 150,
+          alignment = 'right'
+        },
+        f:edit_field {
+          value = bind('previewDelay'),
+          width_in_chars = 8,
+          immediate = true
+        }
+      }
+    }
+  }
+
+  local tabView = f:tab_view {
+    f:tab_view_item {
+      title = 'General',
+      generalTab
+    },
+    f:tab_view_item {
+      title = 'Bracket Stacking',
+      bracketTab
+    }
+  }
+
+  -- Main dialog content
   local c = f:column {
     bind_to_object = prefs,
     spacing = f:control_spacing(),
-    
-    f:static_text { 
-      title = 'WildlifeAI Configuration', 
+
+    f:static_text {
+      title = 'WildlifeAI Configuration',
       font = '<system/bold>',
-      fill_horizontal = 1 
+      fill_horizontal = 1
     },
-    
+
     f:spacer { height = 10 },
-    
-    -- Two-column layout
-    f:row {
-      spacing = 15,
-      leftColumn,
-      rightColumn
-    }
+
+    tabView
   }
   
   -- Initial validation


### PR DESCRIPTION
## Summary
- Add bracket stacking defaults and configuration tab in ConfigDialog
- Include controls for time thresholds, exposure analysis, panorama detection, stack behavior, and preview

## Testing
- `pytest` *(fails: AttributeError, KeyError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6896623adab883229b453b1111587777