### PR TITLE
Add bracket prefs and config import/export

### DIFF
--- a/plugin/WildlifeAI.lrplugin/PluginInit.lua
+++ b/plugin/WildlifeAI.lrplugin/PluginInit.lua
@@ -23,6 +23,11 @@ local function setupDefaultPrefs()
   prefs.generateCrops   = prefs.generateCrops   ~= false -- default true
   prefs.useGPU          = prefs.useGPU          or false
   prefs.maxWorkers      = prefs.maxWorkers      or 4
+
+  -- Bracket processing options
+  if prefs.enableBracketProcessing == nil then prefs.enableBracketProcessing = false end
+  prefs.bracketGroupSize = prefs.bracketGroupSize or 3
+  prefs.bracketStepEV    = prefs.bracketStepEV    or 1
   
   -- Per-photo processing options
   if prefs.perPhotoOutput == nil then prefs.perPhotoOutput = true end -- default enabled


### PR DESCRIPTION
## Summary
- initialize bracket processing preferences with sane defaults
- add JSON-based import/export utilities to config dialog
- wire settings dialog with Import/Export buttons

## Testing
- `pytest` *(fails: AttributeError, missing TensorFlow in runner)*

------
https://chatgpt.com/codex/tasks/task_e_6896624157dc832292a5416aba356048