### PR TITLE
Add async bracket analysis with progress and metadata caching

### DIFF
--- a/plugin/WildlifeAI.lrplugin/Menu/AnalyzeBrackets.lua
+++ b/plugin/WildlifeAI.lrplugin/Menu/AnalyzeBrackets.lua
@@ -1,10 +1,7 @@
 local LrFunctionContext = import 'LrFunctionContext'
-local LrTasks = import 'LrTasks'
 local LrPathUtils = import 'LrPathUtils'
 
-LrTasks.startAsyncTask(function()
-  LrFunctionContext.callWithContext('WAI_AnalyzeBrackets', function()
-    local BracketStacking = dofile(LrPathUtils.child(_PLUGIN.path, 'BracketStacking.lua'))
-    BracketStacking.analyze()
-  end)
+LrFunctionContext.callWithContext('WAI_AnalyzeBrackets', function()
+  local BracketStacking = dofile(LrPathUtils.child(_PLUGIN.path, 'BracketStacking.lua'))
+  BracketStacking.analyze()
 end)


### PR DESCRIPTION
## Summary
- Cache capture time and exposure metadata to reduce repeated reads
- Run bracket analysis asynchronously with `LrTasks.startAsyncTask` and progress updates
- Simplify Analyze Brackets menu to invoke async analyzer directly

## Testing
- `pytest` (fails: AttributeError in EnhancedModelRunner and other tests)

------
https://chatgpt.com/codex/tasks/task_e_68966dc1f3208322bd86a9099fe8b7c3