### PR TITLE
Use original capture time and orientation in bracket grouping

### DIFF
--- a/plugin/WildlifeAI.lrplugin/BracketStacking.lua
+++ b/plugin/WildlifeAI.lrplugin/BracketStacking.lua
@@ -7,6 +7,8 @@ local Log = dofile( LrPathUtils.child(_PLUGIN.path, 'utils/Log.lua') )
 local M = {}
 local lastAnalysis = nil
 
+-- Lightroom metadata fields used: 'dateTimeOriginal' for capture time and 'orientation'
+-- for image rotation. Assumes orientation codes follow EXIF 1-8 specification.
 
 local DEFAULTS = {
   timeGap = 2, -- seconds between shots to be grouped
@@ -14,6 +16,7 @@ local DEFAULTS = {
   expectedBracketSize = 3,
   collapseStacks = true,
   bracketDebugMode = false,
+  orientationTolerance = 0, -- orientation code difference to start new group
 }
 
 local function parseNumber(v)
@@ -58,56 +61,69 @@ local function getOrientation(photo)
 
 end
 
+-- Return capture time using original EXIF date/time field. Lightroom returns
+-- either a numeric epoch value or a formatted string; convert both to seconds.
+local function getCaptureTime(photo)
+  local dt = safeGetMetadata(photo, 'dateTimeOriginal')
+  if type(dt) == 'number' then return dt end
+  if type(dt) == 'string' then
+    local y,mo,d,h,mi,s = dt:match('^(%d+):(%d+):(%d+) (%d+):(%d+):(%d+)')
+    if y then
+      return os.time{year=tonumber(y), month=tonumber(mo), day=tonumber(d),
+                     hour=tonumber(h), min=tonumber(mi), sec=tonumber(s)}
+    end
+    return tonumber(dt) or 0
+  end
+  return 0
+end
+
 -- Group photos by capture time
 local function groupByTime(photos, prefs)
   table.sort(photos, function(a,b)
-    return (safeGetMetadata(a, 'captureTime') or 0) < (safeGetMetadata(b, 'captureTime') or 0)
+    return getCaptureTime(a) < getCaptureTime(b)
   end)
   local groups = {}
-  local cur, last = nil, nil
+  local cur
+  local lastCt, lastOr = nil, nil
   local gap = prefs.timeGap or DEFAULTS.timeGap
+  local oTol = prefs.orientationTolerance or DEFAULTS.orientationTolerance -- orientation code tolerance (EXIF 1-8)
   for _,p in ipairs(photos) do
 
-    local ct = safeGetMetadata(p, 'captureTime') or 0
-    if last and prefs.bracketDebugMode then
-      Log.debug(string.format('Time gap to previous: %.2fs', ct - last))
+    local ct = getCaptureTime(p)
+    local o = getOrientation(p)
+    if lastCt and prefs.bracketDebugMode then
+      Log.debug(string.format('Time gap to previous: %.2fs', ct - lastCt))
     end
 
-    if not last or (ct - last) <= gap then
-      if not cur then cur = {photos={}, exposures={}, orientations={}, lowConfidence=false} end
-      table.insert(cur.photos, p)
-      local ev = getExposureValue(p)
-      if not ev then
-        cur.lowConfidence = true
-        Log.warning('Missing exposure data for '..tostring(p))
+    local timeBreak = lastCt and (ct - lastCt) > gap
+    local orientationBreak = false
+    if lastOr and o then
+      -- orientation codes are integers; treat any change beyond tolerance as a new group
+      orientationBreak = math.abs(o - lastOr) > oTol
+      if orientationBreak and prefs.bracketDebugMode then
+        Log.debug(string.format('Orientation change %d -> %d exceeds %d', lastOr, o, oTol))
       end
-      table.insert(cur.exposures, ev or 0)
-      local o = getOrientation(p)
-      if not o then
-        cur.lowConfidence = true
-        Log.warning('Missing orientation for '..tostring(p))
-      end
-      table.insert(cur.orientations, o)
-    else
-      if prefs.bracketDebugMode then
-        Log.debug(string.format('Gap %.2fs exceeds %.2fs, starting new group', ct - last, gap))
-      end
-      table.insert(groups, cur)
-      cur = {photos={p}, exposures={}, orientations={}, lowConfidence=false}
-      local ev = getExposureValue(p)
-      if not ev then
-        cur.lowConfidence = true
-        Log.warning('Missing exposure data for '..tostring(p))
-      end
-      table.insert(cur.exposures, ev or 0)
-      local o = getOrientation(p)
-      if not o then
-        cur.lowConfidence = true
-        Log.warning('Missing orientation for '..tostring(p))
-      end
-      table.insert(cur.orientations, o)
     end
-    last = ct
+
+    if not cur or timeBreak or orientationBreak then
+      if cur then table.insert(groups, cur) end
+      cur = {photos={}, exposures={}, orientations={}, lowConfidence=false}
+    end
+    table.insert(cur.photos, p)
+    local ev = getExposureValue(p)
+    if not ev then
+      cur.lowConfidence = true
+      Log.warning('Missing exposure data for '..tostring(p))
+    end
+    table.insert(cur.exposures, ev or 0)
+    if not o then
+      cur.lowConfidence = true
+      Log.warning('Missing orientation for '..tostring(p))
+    end
+    table.insert(cur.orientations, o)
+
+    lastCt = ct
+    lastOr = o
   end
   if cur and #cur.photos>0 then table.insert(groups, cur) end
   return groups


### PR DESCRIPTION
## Summary
- confirm Lightroom metadata fields `dateTimeOriginal` and `orientation`
- group bracket stacks by EXIF capture time and orientation change
- document capture-time parsing and orientation assumptions

## Testing
- `pytest` *(fails: EnhancedModelRunner missing models and TF dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68966dc69828832287e87803f88ff939