### PR TITLE
Include rawpy libraries in runner build

### DIFF
--- a/python/runner/requirements.txt
+++ b/python/runner/requirements.txt
@@ -9,4 +9,5 @@ Wand>=0.6.13
 pandas>=2.2.3
 PyQt5>=5.15.11
 pyexiftool>=0.5.6
+rawpy>=0.25.1
 requests>=2.32.3

--- a/wildlifeai_runner_cpu.spec
+++ b/wildlifeai_runner_cpu.spec
@@ -7,6 +7,7 @@ from PyInstaller.utils.hooks import collect_all, collect_dynamic_libs
 tf_datas, tf_bins, tf_hidden = collect_all("tensorflow")
 ort_datas, ort_bins, ort_hidden = collect_all("onnxruntime")
 torch_bins = collect_dynamic_libs("torch")
+rawpy_bins = collect_dynamic_libs("rawpy")
 # Collect Microsoft runtime and OpenMP libraries if present
 runtime_bins = []
 for lib in ["msvcp140", "vcruntime140", "libiomp5md"]:
@@ -86,7 +87,7 @@ hiddenimports = [
 
 # Append collected items
 datas += tf_datas + ort_datas
-binaries += tf_bins + ort_bins + torch_bins + runtime_bins
+binaries += tf_bins + ort_bins + torch_bins + runtime_bins + rawpy_bins
 hiddenimports += tf_hidden + ort_hidden
 
 a = Analysis(


### PR DESCRIPTION
## Summary
- bundle rawpy dynamic libraries in PyInstaller spec
- install rawpy via runner requirements

## Testing
- `pytest`
- `pyinstaller wildlifeai_runner_cpu.spec`


------
https://chatgpt.com/codex/tasks/task_e_6896bd3aeff4832283acf1b29a00f272