### PR TITLE
Validate ONNX provider input

### DIFF
--- a/python/runner/project_kestrel_analyzer.py
+++ b/python/runner/project_kestrel_analyzer.py
@@ -15,11 +15,21 @@ SPECIESCLASSIFIER_LABELS = "models/labels.txt"
 QUALITYCLASSIFIER_PATH = "models/quality.keras"
 
 # prompt user for ONNX inference provider
-onnx_provider_input = input("Do you want to use GPU for ONNX inference? (y/n): ").strip().lower()
+onnx_provider_input = input(
+    "Do you want to use GPU for ONNX inference? (y/n): "
+).strip().lower()
+
+# Default to CPU inference unless user explicitly selects GPU
+ONNX_USE_GPU = False
 if onnx_provider_input == 'y':
     ONNX_USE_GPU = True
 elif onnx_provider_input == 'n':
-    ONNX_USE_GPU = False
+    pass
+else:
+    print(
+        "Warning: invalid input for GPU selection. Using CPU for ONNX inference."
+    )
+
 if ONNX_USE_GPU:
     ONNX_PROVIDER = ['DmlExecutionProvider']
 else:


### PR DESCRIPTION
## Summary
- validate ONNX GPU input and default to CPU if invalid

## Testing
- `pytest -q` (fails: AttributeError: 'EnhancedModelRunner' object has no attribute 'species_session' ... 7 failed, 14 passed, 1 skipped)

------
https://chatgpt.com/codex/tasks/task_e_6896c6db11e08322be0418fad670abe8