### PR TITLE
Ensure JSON files saved to output directory

### DIFF
--- a/python/runner/kestrel_parser.py
+++ b/python/runner/kestrel_parser.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+
+
 def to_lightroom_json(raw, src_path, output_dir):
+    json_path = Path(output_dir) / Path(src_path).with_suffix('.json').name
     return {
         'source_path': src_path,
-        'json_path': str(Path(src_path).with_suffix('.json')),
-        'detected_species': raw.get('detected_species') or raw.get('species',''),
+        'json_path': str(json_path),
+        'detected_species': raw.get('detected_species') or raw.get('species', ''),
         'species_confidence': int(raw.get('species_confidence', 0)),
         'quality': int(raw.get('quality', 0)),
         'rating': int(raw.get('rating', 0)),


### PR DESCRIPTION
## Summary
- route JSON outputs to the provided output directory in kestrel_parser

## Testing
- `pytest` *(fails: AttributeError/AssertionError in TestEnhancedRunner)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6df80a88322a75c46afd470546c