### PR TITLE
Use context manager for image loading

### DIFF
--- a/python/runner/wai_runner.py
+++ b/python/runner/wai_runner.py
@@ -66,7 +66,8 @@ def load_image(path):
         except Exception as exc:  # pragma: no cover
             logging.warning("Failed to read RAW %s: %s", path, exc)
     if img is None:
-        img = np.array(Image.open(path).convert("RGB"))
+        with Image.open(path) as img_src:
+            img = np.array(img_src.convert("RGB"))
 
     if cv2:
         img = cv2.resize(img, (224, 224))


### PR DESCRIPTION
## Summary
- prevent file descriptor leaks when loading RGB images

## Testing
- `pytest -q` *(fails: EnhancedModelRunner missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6e01ddc8322b00164d15f1f84bc