### PR TITLE
refactor: use standalone keras imports

### DIFF
--- a/python/runner/project_kestrel_analyzer.py
+++ b/python/runner/project_kestrel_analyzer.py
@@ -4,10 +4,10 @@ import cv2
 import numpy as np
 from PIL import Image
 import torchvision.transforms as T
-import tensorflow as tf
 import onnxruntime as ort
 from wand.image import Image as WandImage
 import pandas as pd
+import keras
 
 SPECIESCLASSIFIER_PATH = "models/model.onnx"
 SPECIESCLASSIFIER_LABELS = "models/labels.txt"
@@ -288,7 +288,7 @@ class BirdSpeciesClassifier:
 class QualityClassifier:
     def __init__(self, model_path):
         self.model_path = model_path
-        self.model = tf.keras.models.load_model(self.model_path)
+        self.model = keras.models.load_model(self.model_path, safe_mode=False)
     def __preprocess_image_classifier(self, cropped_img, cropped_mask):
         img = cv2.cvtColor(cropped_img, cv2.COLOR_RGB2GRAY)  # shape: (1024, 1024)
         # Take derivative of image using Sobel filter

--- a/python/runner/wildlifeai_runner.py
+++ b/python/runner/wildlifeai_runner.py
@@ -30,7 +30,7 @@ except ImportError:
 # Try to import TensorFlow directly for PyInstaller compatibility
 try:
     import tensorflow as tf
-    from tensorflow import keras
+    import keras
     _tensorflow_available = True
 except ImportError:
     tf = None
@@ -44,7 +44,7 @@ def load_tensorflow():
     # Force reimport attempt for PyInstaller compatibility
     try:
         import tensorflow as _tf
-        from tensorflow import keras as _keras
+        import keras as _keras
         tf = _tf
         keras = _keras
         _tensorflow_available = True
@@ -460,7 +460,7 @@ class QualityClassifier:
     
     def __init__(self, model_path):
         self.model_path = model_path
-        self.model = tf.keras.models.load_model(self.model_path)
+        self.model = keras.models.load_model(self.model_path, safe_mode=False)
         
     def _preprocess_image_classifier(self, cropped_img, cropped_mask):
         """Preprocess image for quality classification (exact original implementation)."""


### PR DESCRIPTION
## Summary
- use standalone `keras` instead of `tf.keras`
- load TensorFlow and Keras separately and disable safe mode when loading models

## Testing
- `pytest -q` (fails: EnhancedModelRunner tests require TensorFlow, PyTorch, and other dependencies)

------
https://chatgpt.com/codex/tasks/task_e_6897758a17cc8322b448de50d065d75f