### PR TITLE
Add Keras dependency for runner

### DIFF
--- a/python/runner/requirements.txt
+++ b/python/runner/requirements.txt
@@ -1,6 +1,7 @@
 torch>=2.4.1
 torchvision>=0.19.1
 tensorflow>=2.18,<2.19
+keras>=3.5.0
 onnxruntime-directml>=1.22.0   # use onnxruntime on macOS
 numpy<2.1.0
 opencv-python>=4.11.0


### PR DESCRIPTION
## Summary
- add keras dependency after tensorflow in Python runner requirements

## Testing
- `timeout 30 bash scripts/freeze_mac.sh` *(fails: operation cancelled)*
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68977590aaec832290cf706bf03ed7a4