### PR TITLE
Use LrTasks.pcall for metadata extraction

### DIFF
--- a/plugin/WildlifeAI.lrplugin/BracketStacking.lua
+++ b/plugin/WildlifeAI.lrplugin/BracketStacking.lua
@@ -6,6 +6,7 @@ local LrApplication = import 'LrApplication'
 local LrPrefs = import 'LrPrefs'
 local LrPathUtils = import 'LrPathUtils'
 local LrProgressScope = import 'LrProgressScope'
+local LrTasks = import 'LrTasks'
 
 local Log = dofile( LrPathUtils.child(_PLUGIN.path, 'utils/Log.lua') )
 
@@ -57,7 +58,7 @@ function BracketStacking.extractPhotoMetadata(photos)
   
   -- Process all photos and extract metadata safely
   for i, photo in ipairs(photos) do
-    local success, data = pcall(function()
+    local success, data = LrTasks.pcall(function()
       local timestamp = getPhotoTimestamp(photo)
       local exposureValue = getExposureValue(photo)
       local orientation = getOrientation(photo)


### PR DESCRIPTION
## Summary
- Import `LrTasks` to use Lightroom's task utilities
- Replace Lua's `pcall` with `LrTasks.pcall` in metadata extraction to prevent yielding errors

## Testing
- `pytest -q` *(fails: Missing models and dependencies; 7 failed, 14 passed, 1 skipped)*
- `pytest tests/test_bracket_stacking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68980c454a888322b509f80a35313303