### PR TITLE
Ensure stacking dialog validates top photo

### DIFF
--- a/plugin/WildlifeAI.lrplugin/UI/StackingDialog.lua
+++ b/plugin/WildlifeAI.lrplugin/UI/StackingDialog.lua
@@ -367,16 +367,27 @@ return function(context, photos)
               
               -- Create new stack with highest quality photo on top
               local topPhoto = photosToStack[1]
-              for i = 2, #photosToStack do
-                topPhoto:addToStack(photosToStack[i])
+              -- Verify the top photo is a valid LrPhoto instance
+              local isPhoto = false
+              if topPhoto then
+                local ok = pcall(function() topPhoto:getRawMetadata('uuid') end)
+                isPhoto = ok and type(topPhoto.addToStack) == 'function'
               end
-              
-              -- Collapse if requested
-              if prefs.collapseStacks then
-                topPhoto:setStackCollapsed(true)
+
+              if isPhoto then
+                for i = 2, #photosToStack do
+                  topPhoto:addToStack(photosToStack[i])
+                end
+
+                -- Collapse if requested
+                if prefs.collapseStacks and type(topPhoto.setStackCollapsed) == 'function' then
+                  topPhoto:setStackCollapsed(true)
+                end
+
+                stackCount = stackCount + 1
+              else
+                LrDialogs.message('Stacking Error', 'Cannot create stack: invalid top photo.')
               end
-              
-              stackCount = stackCount + 1
             end
           end
         end

--- a/tests/manual/stacking_dialog_invalid_top_photo.lua
+++ b/tests/manual/stacking_dialog_invalid_top_photo.lua
@@ -1,0 +1,42 @@
+-- Manual test script for StackingDialog invalid top photo handling
+-- Simulates the stacking logic with an invalid top photo to ensure
+-- the dialog reports an error instead of failing.
+
+local function simulateStackCreation()
+  -- Stub dialog to capture messages
+  local LrDialogs = {
+    message = function(title, msg)
+      print(string.format("%s: %s", title, msg))
+    end,
+  }
+
+  -- Preferences stub
+  local prefs = { collapseStacks = true }
+
+  -- Photos array where the first entry lacks addToStack
+  local photosToStack = {
+    {}, -- Invalid top photo
+    { id = 2 },
+    { id = 3 },
+  }
+
+  local topPhoto = photosToStack[1]
+  local isPhoto = false
+  if topPhoto then
+    local ok = pcall(function() return topPhoto:getRawMetadata('uuid') end)
+    isPhoto = ok and type(topPhoto.addToStack) == 'function'
+  end
+
+  if isPhoto then
+    for i = 2, #photosToStack do
+      topPhoto:addToStack(photosToStack[i])
+    end
+    if prefs.collapseStacks and type(topPhoto.setStackCollapsed) == 'function' then
+      topPhoto:setStackCollapsed(true)
+    end
+  else
+    LrDialogs.message('Stacking Error', 'Cannot create stack: invalid top photo.')
+  end
+end
+
+simulateStackCreation()


### PR DESCRIPTION
## Summary
- validate `topPhoto` is a usable LrPhoto before stacking
- add manual Lua script to reproduce invalid top photo handling

## Testing
- `lua tests/manual/stacking_dialog_invalid_top_photo.lua`
- `pytest tests/test_labels.py`

------
https://chatgpt.com/codex/tasks/task_e_689813f780688322ab6322b4d4c8466a