### PR TITLE
Use UUIDs for photo resolution

### DIFF
--- a/plugin/WildlifeAI.lrplugin/BracketPreview.lua
+++ b/plugin/WildlifeAI.lrplugin/BracketPreview.lua
@@ -31,9 +31,9 @@ local function formatTimestamp(timestamp)
   return "Unknown"
 end
 
--- Helper function to get photo name
-local function getPhotoName(photo)
-  return photo:getFormattedMetadata('fileName') or 'Unknown'
+-- Helper function to get photo name from metadata
+local function getPhotoName(photoData)
+  return photoData.fileName or 'Unknown'
 end
 
 -- Create summary statistics section
@@ -132,8 +132,8 @@ local function createResultsTable(f, detectionResults, props)
   -- Build table data from detection results
   for _, sequence in ipairs(detectionResults.sequences) do
     for bracketIndex, bracket in ipairs(sequence.brackets) do
-      local firstPhoto = bracket.photos[1].photo
-      local lastPhoto = bracket.photos[#bracket.photos].photo
+      local firstPhoto = bracket.photos[1]
+      local lastPhoto = bracket.photos[#bracket.photos]
       local timeSpan = bracket.duration
       
       -- Determine issues

--- a/plugin/WildlifeAI.lrplugin/Menu/AnalyzeBrackets.lua
+++ b/plugin/WildlifeAI.lrplugin/Menu/AnalyzeBrackets.lua
@@ -68,16 +68,16 @@ LrTasks.startAsyncTask(function()
       photos = catalog:getTargetPhotos()
       Log.info("Got " .. #photos .. " photos")
       
-      -- Create basic info WITHOUT calling ANY photo methods (no metadata extraction)
-      for i = 1, #photos do
-        -- Don't call ANY methods on photo objects - just store the index
+      -- Extract basic info including UUID for each photo
+      for i, photo in ipairs(photos) do
+        local uuid = photo:getRawMetadata('uuid')
+        local fileName = photo:getFormattedMetadata('fileName') or ('Photo_' .. i)
         local info = {
-          photoIndex = i,
-          photoId = 'photo_' .. i,  -- Simple string ID
-          fileName = 'Photo_' .. i
+          photoId = uuid,
+          fileName = fileName
         }
         table.insert(basicPhotoInfo, info)
-        Log.debug("Basic info for photo " .. i .. ": ID=" .. info.photoId)
+        Log.debug("Basic info for photo " .. i .. ": ID=" .. tostring(info.photoId))
       end
     end)
     


### PR DESCRIPTION
## Summary
- record each photo's UUID during metadata extraction
- resolve stack photos by UUID instead of index
- switch preview and detection flow to rely on UUID metadata

## Testing
- `pytest` *(fails: EnhancedModelRunner missing methods; exposure tests return None)*

------
https://chatgpt.com/codex/tasks/task_e_68982434b3788322bf2efd809e5e23fa