### PR TITLE
Use LrTasks.pcall for safe metadata access

### DIFF
--- a/plugin/WildlifeAI.lrplugin/BracketStacking.lua
+++ b/plugin/WildlifeAI.lrplugin/BracketStacking.lua
@@ -17,7 +17,7 @@ local EPSILON = 0.001 -- For floating point comparisons
 
 -- Safely retrieve metadata with error handling
 local function safeGetRawMetadata(photo, key)
-  local ok, result = pcall(function()
+  local ok, result = LrTasks.pcall(function()
     return photo:getRawMetadata(key)
   end)
   if ok then


### PR DESCRIPTION
## Summary
- Use `LrTasks.pcall` in `safeGetRawMetadata` to avoid Lightroom task yielding warnings while preserving success/failure logging

## Testing
- `pytest` *(fails: EnhancedRunner tests missing ML dependencies like TensorFlow and PyTorch)*
- Manual Lua run of `extractPhotoMetadataSafe` shows successful metadata retrieval without warnings

------
https://chatgpt.com/codex/tasks/task_e_68994105f53c8322a935df7ed845c3d0